### PR TITLE
initial dockerfile, should work, comes with caching for local builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM rust as planner
+WORKDIR /app
+RUN cargo install cargo-chef
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM rust as cacher
+WORKDIR /app
+RUN cargo install cargo-chef
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+
+FROM rust as builder
+WORKDIR /app
+COPY . .
+COPY --from=cacher /app/target target
+COPY --from=cacher $CARGO_HOME $CARGO_HOME
+RUN rustup target add x86_64-unknown-linux-musl
+RUN cargo install --target x86_64-unknown-linux-musl --path .
+
+FROM scratch
+COPY --from=builder /usr/local/cargo/bin/wurtle-api ./app
+EXPOSE 8080
+ENTRYPOINT ["./app"]


### PR DESCRIPTION
This uses cargo-chef to build a cache of the various requirements, which significantly reduces the time to building docker images.